### PR TITLE
Porting the fixes/hacks from the original IQSS fork

### DIFF
--- a/xoai-common/src/main/java/io/gdcc/xoai/model/oaipmh/GetRecord.java
+++ b/xoai-common/src/main/java/io/gdcc/xoai/model/oaipmh/GetRecord.java
@@ -31,6 +31,13 @@ public class GetRecord implements Verb {
         }
     }
 
+    /* Not to be confused with the similarly-named constructor, this
+       method exposes the "private final Record record" to other parts
+       of the OAI framework: */ 
+    public Record getRecord() {
+        return record;
+    }
+    
     @Override
     public Type getType() {
         return Type.GetRecord;

--- a/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/GetRecordHandler.java
+++ b/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/GetRecordHandler.java
@@ -47,6 +47,10 @@ public class GetRecordHandler extends VerbHandler<GetRecord> {
         GetRecord result = new GetRecord(record);
 
         MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
+        if (format == null) {
+            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" not applicable to this item");
+        }
+
         Item item = getRepository().getItemRepository().getItem(parameters.getIdentifier());
 
         if (getContext().hasCondition() &&

--- a/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/GetRecordHandler.java
+++ b/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/GetRecordHandler.java
@@ -47,10 +47,6 @@ public class GetRecordHandler extends VerbHandler<GetRecord> {
         GetRecord result = new GetRecord(record);
 
         MetadataFormat format = getContext().formatForPrefix(parameters.getMetadataPrefix());
-        if (format == null) {
-            throw new CannotDisseminateFormatException("Format "+parameters.getMetadataPrefix()+" not applicable to this item");
-        }
-
         Item item = getRepository().getItemRepository().getItem(parameters.getIdentifier());
 
         if (getContext().hasCondition() &&
@@ -72,10 +68,13 @@ public class GetRecordHandler extends VerbHandler<GetRecord> {
         for (Set set : item.getSets())
             header.withSetSpec(set.getSpec());
 
-        if (item.isDeleted())
+        if (item.isDeleted()) {
             header.withStatus(Header.Status.DELETED);
-
-        if (!item.isDeleted()) {
+        } else {
+            /* Include the raw pre-exported metadata: */
+            record.withMetadata(item.getMetadata());
+            
+            /* Bypass/disable the XOAI metadata pipeline: 
             Metadata metadata;
             try {
                 if (getContext().hasTransformer()) {
@@ -98,6 +97,7 @@ public class GetRecordHandler extends VerbHandler<GetRecord> {
                 for (About about : item.getAbout())
                     record.withAbout(about);
             }
+            */
         }
         return result;
     }

--- a/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/ListIdentifiersHandler.java
+++ b/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/ListIdentifiersHandler.java
@@ -49,6 +49,7 @@ public class ListIdentifiersHandler extends VerbHandler<ListIdentifiers> {
         if (parameters.hasSet() && !getRepository().getSetRepository().supportSets())
             throw new DoesNotSupportSetsException();
 
+        /* This check is likely redundant/unnecessary here (?) -- L.A. */
         PreconditionHelper.checkMetadataFormat(getContext(), parameters.getMetadataPrefix());
 
         int length = getRepository().getConfiguration().getMaxListIdentifiers();
@@ -69,8 +70,10 @@ public class ListIdentifiersHandler extends VerbHandler<ListIdentifiers> {
                 listItemIdentifiersResult = itemRepositoryHelper.getItemIdentifiers(getContext(), offset, length,
                         parameters.getMetadataPrefix());
         } else {
-            if (!getRepository().getSetRepository().exists(parameters.getSet()) && !getContext().hasSet(parameters.getSet()))
-                throw new NoMatchesException();
+            /* TBH, I don't remember why the 2 lines below are commented out in 
+               the original IQSS fork. Will check. -- L.A. */
+            /*if (!getRepository().getSetRepository().exists(parameters.getSet()) && !getContext().hasSet(parameters.getSet()))
+                throw new NoMatchesException();*/
 
             if (parameters.hasFrom() && !parameters.hasUntil())
                 listItemIdentifiersResult = itemRepositoryHelper.getItemIdentifiers(getContext(), offset, length,
@@ -121,7 +124,7 @@ public class ListIdentifiersHandler extends VerbHandler<ListIdentifiers> {
     private Header createHeader(OAICompiledRequest parameters,
                                     ItemIdentifier itemIdentifier) throws BadArgumentException,
             OAIException,
-        NoMetadataFormatsException {
+            NoMetadataFormatsException {
         MetadataFormat format = getContext().formatForPrefix(parameters
                 .getMetadataPrefix());
         if (!itemIdentifier.isDeleted() && !canDisseminate(itemIdentifier, format))


### PR DESCRIPTION
These are the changes from the local fork that were needed to get this thing to work with the Dataverse model of exporting and storing metadata. 
I'd like to achieve an intermediate result of being able to build Dataverse from the current develop branch with these new gdcc/xoai libraries and have all the OAI parts work exactly as they are working now, when built with the old jars in local_lib. Before we proceed with any further cleanup and refactoring. 

I'll try to explain what these changes do and why that model was chosen. 

ref. #2 