### PR TITLE
Fixes the numbering scheme in the XOAI resumption token cursor

### DIFF
--- a/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/helpers/ResumptionTokenHelper.java
+++ b/xoai-data-provider/src/main/java/io/gdcc/xoai/dataprovider/handlers/helpers/ResumptionTokenHelper.java
@@ -40,7 +40,7 @@ public class ResumptionTokenHelper {
             } else {
                 ResumptionToken resumptionToken = new ResumptionToken();
                 // add 0.0f to make it a floating operation instead of an integer division (Math.round() expects float!)
-                resumptionToken.withCursor(round((current.getOffset() + 0.0f + maxPerPage) / maxPerPage));
+                resumptionToken.withCursor(round((current.getOffset() + 0.0f) / maxPerPage));
                 if (totalResults != null)
                     resumptionToken.withCompleteListSize(totalResults);
                 return resumptionToken;
@@ -56,7 +56,7 @@ public class ResumptionTokenHelper {
         if (totalResults != null)
             resumptionToken.withCompleteListSize(totalResults);
         // add 0.0f to make it a floating operation instead of an integer division (Math.round() expects float!)
-        resumptionToken.withCursor(round((resumptionToken.getValue().getOffset() +0.0f) / maxPerPage));
+        resumptionToken.withCursor(round((resumptionToken.getValue().getOffset() +0.0f - maxPerPage) / maxPerPage));
         return resumptionToken;
     }
 }


### PR DESCRIPTION
copy-and-pasting from #30: 

The OAI spec says the cursor position should start with 0; the XOAI implementation starts with 1. 
I.e., currently the resumption token under the 1st page of results looks like this:
```
<resumptionToken cursor="1">
   MToxMDB8Mjp8Mzp8NDp8NTpvYWlfZGM=
</resumptionToken>
```
It should instead say `cursor="0"` etc. 

Closes #30