### PR TITLE
Added error handling if resumption token is not a valid base64 string

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ mvn spotless:check
 
 ## Release notes
 
+### v5.2.2
+
+#### 🌟 FEATURES
+- (none)
+
+#### 💔 BREAKING CHANGES
+- (none)
+
+#### 🏹 BUG FIXES
+- Catch invalid Base64 encodings for resumption tokens (#272) - a community contribution by @bumann-sbb 💫
+
 ### v5.2.1
 
 #### 🌟 FEATURES

--- a/xoai-common/src/main/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormat.java
+++ b/xoai-common/src/main/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormat.java
@@ -124,12 +124,16 @@ public class SimpleResumptionTokenFormat implements ResumptionTokenFormat {
      * @param value The Base64 encoded string
      * @return A decoded String (may be empty)
      */
-    static String base64Decode(String value) {
+    static String base64Decode(String value) throws BadResumptionTokenException {
         if (value == null) {
             return null;
         }
-        byte[] decodedValue = Base64.getDecoder().decode(value);
-        return new String(decodedValue, StandardCharsets.UTF_8);
+        try {
+            byte[] decodedValue = Base64.getDecoder().decode(value);
+            return new String(decodedValue, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new BadResumptionTokenException("Token has no valid base64 encoding", e);
+        }
     }
 
     static String base64Encode(String value) {

--- a/xoai-common/src/test/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormatTest.java
+++ b/xoai-common/src/test/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormatTest.java
@@ -9,6 +9,7 @@ import io.gdcc.xoai.services.api.ResumptionTokenFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -72,5 +73,17 @@ class SimpleResumptionTokenFormatTest {
     void validParse(String token) {
         String encoded = SimpleResumptionTokenFormat.base64Encode(token);
         assertDoesNotThrow(() -> format.parse(encoded));
+    }
+
+    @Test
+    void validBase64Decoding() {
+        assertDoesNotThrow(() -> SimpleResumptionTokenFormat.base64Decode("b2Zmc2V0OjoxMDA="));
+    }
+
+    @Test
+    void invalidBase64Decoding() {
+        assertThrows(
+                BadResumptionTokenException.class,
+                () -> SimpleResumptionTokenFormat.base64Decode("b2Zmc2V0OjoMDA="));
     }
 }

--- a/xoai-common/src/test/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormatTest.java
+++ b/xoai-common/src/test/java/io/gdcc/xoai/services/impl/SimpleResumptionTokenFormatTest.java
@@ -1,6 +1,8 @@
 package io.gdcc.xoai.services.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.gdcc.xoai.exceptions.BadResumptionTokenException;
 import io.gdcc.xoai.model.oaipmh.Granularity;
@@ -9,7 +11,6 @@ import io.gdcc.xoai.services.api.ResumptionTokenFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -69,21 +70,22 @@ class SimpleResumptionTokenFormatTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    @ValueSource(strings = {"    ", "\t\t\t", "offset::1|", "until::2022-05-13T10:00:00Z"})
+    @ValueSource(
+            strings = {
+                "    ",
+                "\t\t\t",
+                "offset::1|",
+                "until::2022-05-13T10:00:00Z",
+                "offset::1|set::Ätherische Öle"
+            })
     void validParse(String token) {
         String encoded = SimpleResumptionTokenFormat.base64Encode(token);
         assertDoesNotThrow(() -> format.parse(encoded));
     }
 
-    @Test
-    void validBase64Decoding() {
-        assertDoesNotThrow(() -> SimpleResumptionTokenFormat.base64Decode("b2Zmc2V0OjoxMDA="));
-    }
-
-    @Test
-    void invalidBase64Decoding() {
-        assertThrows(
-                BadResumptionTokenException.class,
-                () -> SimpleResumptionTokenFormat.base64Decode("b2Zmc2V0OjoMDA="));
+    @ParameterizedTest
+    @ValueSource(strings = {"b2Zmc2V0OjoMDA=", "VG========"})
+    void invalidBase64Parse(String sut) {
+        assertThrows(BadResumptionTokenException.class, () -> format.parse(sut));
     }
 }


### PR DESCRIPTION
When sending an invalid resumption token (not a valid base64 encoded String) the library throws an unhandled exception (`IllegalArgumentException`).
This change handles this exception and throws a `BadResumptionTokenException` and thus produces a valid OAI PMH response.