### PR TITLE
HTTP 500 fix when having many requests in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ mvn spotless:check
 - (none)
 
 #### 🏹 BUG FIXES
+- Fix a thread safety issue in CopyElement (Shoutout to @ErykKul for #283!)
 - Make Service Provider XML parsing more secure and avoid XXEs (activate STaX2 security features)
 - Make Service Provider XML parsing thread-safe (use thread-local variants of XmlInputFactory)
 - Switch to Sonatype Central Portal to [replace sunset OSSRH](https://central.sonatype.org/pages/ossrh-eol/)

--- a/xoai-common/src/main/java/io/gdcc/xoai/xml/CopyElement.java
+++ b/xoai-common/src/main/java/io/gdcc/xoai/xml/CopyElement.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 

--- a/xoai-common/src/main/java/io/gdcc/xoai/xml/CopyElement.java
+++ b/xoai-common/src/main/java/io/gdcc/xoai/xml/CopyElement.java
@@ -66,10 +66,10 @@ public class CopyElement implements XmlWritable {
     }
 
     /**
-     * A matcher, created only once, reusable to match the XML declaration with any attributes.
+     * A pattern, created only once, reusable to match the XML declaration with any attributes.
      * Non-greedy, so we do not interfere with any XML processing instructions following.
      */
-    private static final Matcher xmlDeclaration = Pattern.compile("<\\?xml .*?\\?>").matcher("");
+    private static final Pattern xmlDeclaration = Pattern.compile("<\\?xml .*?\\?>");
 
     protected void writeXml(XmlWriter writer) throws IOException {
 
@@ -109,7 +109,7 @@ public class CopyElement implements XmlWritable {
 
             String firstChars = new String(bytes, StandardCharsets.UTF_8);
             // match the start with the compiled regex and replace with nothing when matching.
-            firstChars = xmlDeclaration.reset(firstChars).replaceFirst("");
+            firstChars = xmlDeclaration.matcher(firstChars).replaceFirst("");
 
             // write the chars to the output stream
             writer.getOutputStream().write(firstChars.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Hi,

We have implemented an OAI interface using this library and our DB as source. When doing a load test, we noticed some HTTP 500 errors caused by the use of an instance (in a static field) of the java.util.regex.Matcher class, which is not safe to use in concurrent threads. In this PR, the static field is replaced by an instance of java.util.regex.Pattern class, which is thread safe, and should fix the problem.